### PR TITLE
Fix docstring for tdnoisefit

### DIFF
--- a/src/thztools/thztools.py
+++ b/src/thztools/thztools.py
@@ -524,7 +524,8 @@ def tdnoisefit(
     x : ndarray
         Data array.
     v0 : ndarray, optional
-        Initial guess, noise model parameters with size (3,).
+        Initial guess, noise model parameters with size (3,), expressed as
+        variance amplitudes.
     mu0 : ndarray, optional
         Initial guess, signal vector with size (n,).
     a0 : ndarray, optional
@@ -547,7 +548,7 @@ def tdnoisefit(
     p : dict
         Output parameter dictionary containing:
             var : ndarray
-                Log of noise parameters
+                Noise parameters, expressed as variance amplitudes.
             mu : ndarray
                 Signal vector.
             a : ndarray


### PR DESCRIPTION
Fixed docstring for `var` key in returned `p` dictionary; also specified that it refers to the variance amplitudes in both the `var` output and the `v0` input.