### PR TITLE
22 GitHub action is not triggered when expected

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -45,9 +45,9 @@ jobs:
         skip_existing: true
 
     - name: Publish distribution 📦 to PyPI
-      if: startsWith(github.ref, 'refs/tags')
+#      if: startsWith(github.ref, 'refs/tags')
       # The line above is the old code from PyPA, the line below is from @lwasser
-      # if: github.event_name == 'release'
+      if: github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI }}

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,8 +1,13 @@
 name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+# Modified from https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/# ,
+# based on suggestions from https://pyopensci.discourse.group/t/trouble-github-action-for-publishing-to-pypi/355?u=jsdodge .
 
 on:
+  release:
+    types: [published]
   push:
-    branches: [ 'main' ]
+    branches:
+      - main
 
 jobs:
   build-n-publish:
@@ -32,12 +37,17 @@ jobs:
         .
 
     - name: Publish distribution 📦 to Test PyPI
+      if: github.event_name == 'push'
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.TEST_PYPI }}
         repository-url: https://test.pypi.org/legacy/
+        skip_existing: true
+
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
+      # The line above is the old code from PyPA, the line below is from @lwasser
+      # if: github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI }}


### PR DESCRIPTION
Includes changes suggested [here](https://pyopensci.discourse.group/t/trouble-github-action-for-publishing-to-pypi/355?u=jsdodge), to trigger publishing to PyPI.