### PR TITLE
Added Test Paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ exclude_lines = [
 addopts = [
     "--import-mode=importlib",
 ]
+testpaths = ["tests"]
 
 [tool.hatch.envs.docs]
 dependencies = [


### PR DESCRIPTION
I added the testpaths parameter, as set one of the item to "tests". This sets pytest to only search the "tests" folder when looking for tests. This prevents it from grabbing files from other directories that aren't tests.