### PR TITLE
Fix `eta` scaling issue in `_parse_noisefit_input`

### DIFF
--- a/src/thztools/thztools.py
+++ b/src/thztools/thztools.py
@@ -2571,9 +2571,9 @@ def _parse_noisefit_input(
             _epsilon = epsilon0
         else:
             _epsilon = _p[: m - 1]
-            _p = _p[m - 1 :]
+            _p = _p[m - 1:]
 
-        _eta = eta_scaled0 if fix_eta else _p[: m - 1]
+        _eta_on_dt = eta_scaled0 / dt if fix_eta else _p[: m - 1]
 
         return _nll_noisefit(
             x.T,
@@ -2582,7 +2582,7 @@ def _parse_noisefit_input(
             _logv_tau,
             _delta,
             _epsilon,
-            _eta,
+            _eta_on_dt,
             est_mu=est_mu,
             scale_logv_alpha=scale_logv_alpha,
             scale_logv_beta=scale_logv_beta,
@@ -2621,7 +2621,7 @@ def _parse_noisefit_input(
             _epsilon = epsilon0
         else:
             _epsilon = _p[: m - 1]
-            _p = _p[m - 1 :]
+            _p = _p[m - 1:]
 
         _eta_on_dt = eta_scaled0 / dt if fix_eta else _p[: m - 1]
 
@@ -2740,7 +2740,7 @@ def _parse_noisefit_output(
         a_out = a0
     else:
         a_out = np.concatenate(([1.0], 1.0 + x_out[: m - 1] * scale_delta_a))
-        x_out = x_out[m - 1 :]
+        x_out = x_out[m - 1:]
 
     if fix_eta:
         eta_out = eta0
@@ -2778,6 +2778,7 @@ def _parse_noisefit_output(
     )
 
     # Get or compute the inverse hessian
+    # hess_inv_scaled = np.linalg.inv(hess(out.x))
     hess_inv_scaled = np.linalg.inv(nd.Jacobian(jac)(out.x))
 
     # Convert inverse Hessian into unscaled parameters
@@ -2817,7 +2818,7 @@ def _parse_noisefit_output(
 
     if not fix_a:
         err_a = np.concatenate(([0], err[: m - 1]))
-        err = err[m - 1 :]
+        err = err[m - 1:]
 
     if not fix_eta:
         err_eta = np.concatenate(([0], err[: m - 1]))
@@ -2828,7 +2829,7 @@ def _parse_noisefit_output(
         f = rfftfreq(n)
         w = 2 * pi * f
 
-        exp_iweta = np.exp(1j * np.outer(eta_out / dt, w))
+        exp_iweta = np.exp(1j * np.outer(eta_out, w / dt))
         x_f = rfft(x.T)
         x_back_f = exp_iweta * x_f
 
@@ -2858,18 +2859,18 @@ def _parse_noisefit_output(
 
         if fix_a and not fix_eta:
             var_a_eta = (
-                dmu_deta[1:].T @ hess_inv[-m + 1 :, -m + 1 :] @ dmu_deta[1:]
+                dmu_deta[1:].T @ hess_inv[-m + 1:, -m + 1:] @ dmu_deta[1:]
             )
         elif not fix_a and fix_eta:
             var_a_eta = (
-                dmu_da[1:].T @ hess_inv[-m + 1 :, -m + 1 :] @ dmu_da[1:]
+                dmu_da[1:].T @ hess_inv[-m + 1:, -m + 1:] @ dmu_da[1:]
             )
         elif fix_a and fix_eta:
             var_a_eta = 0
         else:
             var_a_eta = (
                 np.concatenate((dmu_da[1:], dmu_deta[1:])).T
-                @ hess_inv[-2 * m + 2 :, -2 * m + 2 :]
+                @ hess_inv[-2 * m + 2:, -2 * m + 2:]
                 @ np.concatenate((dmu_da[1:], dmu_deta[1:]))
             )
 
@@ -3367,6 +3368,7 @@ def fit(
         elif n % 2 == 1 and n_below == 0:
             n_b += 1
 
+    # alpha, beta, tau = noise_parms.tolist()
     alpha = noise_parms[0]
     beta = noise_parms[1]
     tau = noise_parms[2]
@@ -3435,8 +3437,8 @@ def fit(
     def function(
         _w: NDArray[np.float64], /, *_theta: np.float64
     ) -> NDArray[np.complex128]:
-        _a = np.asarray(_theta[n_p : n_p + n_a], dtype=np.float64)
-        _b = np.asarray(_theta[n_p + n_a :], dtype=np.float64)
+        _a = np.asarray(_theta[n_p: n_p + n_a], dtype=np.float64)
+        _b = np.asarray(_theta[n_p + n_a:], dtype=np.float64)
         h_ex = fun_ex(_a, _b)
         h_in = _frfun_local(_w[f_incl_idx], *_theta[:n_p])
         return np.concatenate((h_ex[:n_below], h_in, h_ex[n_below:]))
@@ -3459,6 +3461,8 @@ def fit(
                 ].T,
                 np.complex128,
             )
+        if not numpy_sign_convention:
+            return np.conj(out)
         return out
 
     def jacobian_bl(
@@ -3497,7 +3501,7 @@ def fit(
                         np.zeros((n_b, 1)),
                         b_circ[:, : n_below - 1],
                         np.zeros((n_b, n_in)),
-                        b_circ[:, n_below - 1 :],
+                        b_circ[:, n_below - 1:],
                         np.zeros((n_b, 1)),
                     ),
                     axis=-1,
@@ -3518,7 +3522,7 @@ def fit(
                             np.zeros((n_b, 1)),
                             b_circ[:, : n_below - 1],
                             np.zeros((n_b, n_in)),
-                            b_circ[:, n_below - 1 :],
+                            b_circ[:, n_below - 1:],
                         ),
                         axis=-1,
                     )
@@ -3534,7 +3538,7 @@ def fit(
 
     def jac_fun(_x: NDArray[np.float64]) -> NDArray[np.float64]:
         p_est = _x[: n_p + n_a + n_b]
-        mu_est = xdata[:] - _x[n_p + n_a + n_b :]
+        mu_est = xdata[:] - _x[n_p + n_a + n_b:]
         jac_tl = np.zeros((n, n_p + n_a + n_b))
         jac_tr = np.diag(1 / sigma_x)
         fft_mu_est = rfft(mu_est)
@@ -3546,11 +3550,13 @@ def fit(
 
         return np.block([[jac_tl, jac_tr], [jac_bl, jac_br]])
 
+    # print(type(least_squares))
+    # reveal_type(least_squares)
     result = least_squares(
         lambda _p: _costfuntls(
             function,
             _p[: n_p + n_a + n_b],
-            xdata[:] - _p[n_p + n_a + n_b :],
+            xdata[:] - _p[n_p + n_a + n_b:],
             xdata[:],
             ydata[:],
             sigma_x[:],
@@ -3576,10 +3582,10 @@ def fit(
     p_opt = result.x[:n_p]
     p_cov = cov[:n_p, :n_p]
     p_err = np.sqrt(np.diag(p_cov))
-    delta = result.x[n_p + n_a + n_b :]
+    delta = result.x[n_p + n_a + n_b:]
 
     mu_opt = xdata - delta
-    mu_err = np.sqrt(np.diag(cov)[n_p + n_a + n_b :])
+    mu_err = np.sqrt(np.diag(cov)[n_p + n_a + n_b:])
     psi_opt = apply_frf(function, mu_opt, dt=dt, args=p_opt_all)
     epsilon = ydata - psi_opt
     resnorm = 2 * result.cost

--- a/src/thztools/thztools.py
+++ b/src/thztools/thztools.py
@@ -2571,7 +2571,7 @@ def _parse_noisefit_input(
             _epsilon = epsilon0
         else:
             _epsilon = _p[: m - 1]
-            _p = _p[m - 1 :]
+            _p = _p[m - 1:]
 
         _eta_on_dt = eta_scaled0 / dt if fix_eta else _p[: m - 1]
 
@@ -2621,7 +2621,7 @@ def _parse_noisefit_input(
             _epsilon = epsilon0
         else:
             _epsilon = _p[: m - 1]
-            _p = _p[m - 1 :]
+            _p = _p[m - 1:]
 
         _eta_on_dt = eta_scaled0 / dt if fix_eta else _p[: m - 1]
 
@@ -2740,7 +2740,7 @@ def _parse_noisefit_output(
         a_out = a0
     else:
         a_out = np.concatenate(([1.0], 1.0 + x_out[: m - 1] * scale_delta_a))
-        x_out = x_out[m - 1 :]
+        x_out = x_out[m - 1:]
 
     if fix_eta:
         eta_out = eta0
@@ -2778,7 +2778,6 @@ def _parse_noisefit_output(
     )
 
     # Get or compute the inverse hessian
-    # hess_inv_scaled = np.linalg.inv(hess(out.x))
     hess_inv_scaled = np.linalg.inv(nd.Jacobian(jac)(out.x))
 
     # Convert inverse Hessian into unscaled parameters
@@ -2818,7 +2817,7 @@ def _parse_noisefit_output(
 
     if not fix_a:
         err_a = np.concatenate(([0], err[: m - 1]))
-        err = err[m - 1 :]
+        err = err[m - 1:]
 
     if not fix_eta:
         err_eta = np.concatenate(([0], err[: m - 1]))
@@ -2859,18 +2858,18 @@ def _parse_noisefit_output(
 
         if fix_a and not fix_eta:
             var_a_eta = (
-                dmu_deta[1:].T @ hess_inv[-m + 1 :, -m + 1 :] @ dmu_deta[1:]
+                dmu_deta[1:].T @ hess_inv[-m + 1:, -m + 1:] @ dmu_deta[1:]
             )
         elif not fix_a and fix_eta:
             var_a_eta = (
-                dmu_da[1:].T @ hess_inv[-m + 1 :, -m + 1 :] @ dmu_da[1:]
+                dmu_da[1:].T @ hess_inv[-m + 1:, -m + 1:] @ dmu_da[1:]
             )
         elif fix_a and fix_eta:
             var_a_eta = 0
         else:
             var_a_eta = (
                 np.concatenate((dmu_da[1:], dmu_deta[1:])).T
-                @ hess_inv[-2 * m + 2 :, -2 * m + 2 :]
+                @ hess_inv[-2 * m + 2:, -2 * m + 2:]
                 @ np.concatenate((dmu_da[1:], dmu_deta[1:]))
             )
 
@@ -3368,7 +3367,6 @@ def fit(
         elif n % 2 == 1 and n_below == 0:
             n_b += 1
 
-    # alpha, beta, tau = noise_parms.tolist()
     alpha = noise_parms[0]
     beta = noise_parms[1]
     tau = noise_parms[2]
@@ -3437,8 +3435,8 @@ def fit(
     def function(
         _w: NDArray[np.float64], /, *_theta: np.float64
     ) -> NDArray[np.complex128]:
-        _a = np.asarray(_theta[n_p : n_p + n_a], dtype=np.float64)
-        _b = np.asarray(_theta[n_p + n_a :], dtype=np.float64)
+        _a = np.asarray(_theta[n_p: n_p + n_a], dtype=np.float64)
+        _b = np.asarray(_theta[n_p + n_a:], dtype=np.float64)
         h_ex = fun_ex(_a, _b)
         h_in = _frfun_local(_w[f_incl_idx], *_theta[:n_p])
         return np.concatenate((h_ex[:n_below], h_in, h_ex[n_below:]))
@@ -3461,8 +3459,6 @@ def fit(
                 ].T,
                 np.complex128,
             )
-        if not numpy_sign_convention:
-            return np.conj(out)
         return out
 
     def jacobian_bl(
@@ -3501,7 +3497,7 @@ def fit(
                         np.zeros((n_b, 1)),
                         b_circ[:, : n_below - 1],
                         np.zeros((n_b, n_in)),
-                        b_circ[:, n_below - 1 :],
+                        b_circ[:, n_below - 1:],
                         np.zeros((n_b, 1)),
                     ),
                     axis=-1,
@@ -3522,7 +3518,7 @@ def fit(
                             np.zeros((n_b, 1)),
                             b_circ[:, : n_below - 1],
                             np.zeros((n_b, n_in)),
-                            b_circ[:, n_below - 1 :],
+                            b_circ[:, n_below - 1:],
                         ),
                         axis=-1,
                     )
@@ -3538,7 +3534,7 @@ def fit(
 
     def jac_fun(_x: NDArray[np.float64]) -> NDArray[np.float64]:
         p_est = _x[: n_p + n_a + n_b]
-        mu_est = xdata[:] - _x[n_p + n_a + n_b :]
+        mu_est = xdata[:] - _x[n_p + n_a + n_b:]
         jac_tl = np.zeros((n, n_p + n_a + n_b))
         jac_tr = np.diag(1 / sigma_x)
         fft_mu_est = rfft(mu_est)
@@ -3550,13 +3546,11 @@ def fit(
 
         return np.block([[jac_tl, jac_tr], [jac_bl, jac_br]])
 
-    # print(type(least_squares))
-    # reveal_type(least_squares)
     result = least_squares(
         lambda _p: _costfuntls(
             function,
             _p[: n_p + n_a + n_b],
-            xdata[:] - _p[n_p + n_a + n_b :],
+            xdata[:] - _p[n_p + n_a + n_b:],
             xdata[:],
             ydata[:],
             sigma_x[:],
@@ -3582,10 +3576,10 @@ def fit(
     p_opt = result.x[:n_p]
     p_cov = cov[:n_p, :n_p]
     p_err = np.sqrt(np.diag(p_cov))
-    delta = result.x[n_p + n_a + n_b :]
+    delta = result.x[n_p + n_a + n_b:]
 
     mu_opt = xdata - delta
-    mu_err = np.sqrt(np.diag(cov)[n_p + n_a + n_b :])
+    mu_err = np.sqrt(np.diag(cov)[n_p + n_a + n_b:])
     psi_opt = apply_frf(function, mu_opt, dt=dt, args=p_opt_all)
     epsilon = ydata - psi_opt
     resnorm = 2 * result.cost

--- a/src/thztools/thztools.py
+++ b/src/thztools/thztools.py
@@ -2571,7 +2571,7 @@ def _parse_noisefit_input(
             _epsilon = epsilon0
         else:
             _epsilon = _p[: m - 1]
-            _p = _p[m - 1:]
+            _p = _p[m - 1 :]
 
         _eta_on_dt = eta_scaled0 / dt if fix_eta else _p[: m - 1]
 
@@ -2621,7 +2621,7 @@ def _parse_noisefit_input(
             _epsilon = epsilon0
         else:
             _epsilon = _p[: m - 1]
-            _p = _p[m - 1:]
+            _p = _p[m - 1 :]
 
         _eta_on_dt = eta_scaled0 / dt if fix_eta else _p[: m - 1]
 
@@ -2740,7 +2740,7 @@ def _parse_noisefit_output(
         a_out = a0
     else:
         a_out = np.concatenate(([1.0], 1.0 + x_out[: m - 1] * scale_delta_a))
-        x_out = x_out[m - 1:]
+        x_out = x_out[m - 1 :]
 
     if fix_eta:
         eta_out = eta0
@@ -2817,7 +2817,7 @@ def _parse_noisefit_output(
 
     if not fix_a:
         err_a = np.concatenate(([0], err[: m - 1]))
-        err = err[m - 1:]
+        err = err[m - 1 :]
 
     if not fix_eta:
         err_eta = np.concatenate(([0], err[: m - 1]))
@@ -2858,18 +2858,18 @@ def _parse_noisefit_output(
 
         if fix_a and not fix_eta:
             var_a_eta = (
-                dmu_deta[1:].T @ hess_inv[-m + 1:, -m + 1:] @ dmu_deta[1:]
+                dmu_deta[1:].T @ hess_inv[-m + 1 :, -m + 1 :] @ dmu_deta[1:]
             )
         elif not fix_a and fix_eta:
             var_a_eta = (
-                dmu_da[1:].T @ hess_inv[-m + 1:, -m + 1:] @ dmu_da[1:]
+                dmu_da[1:].T @ hess_inv[-m + 1 :, -m + 1 :] @ dmu_da[1:]
             )
         elif fix_a and fix_eta:
             var_a_eta = 0
         else:
             var_a_eta = (
                 np.concatenate((dmu_da[1:], dmu_deta[1:])).T
-                @ hess_inv[-2 * m + 2:, -2 * m + 2:]
+                @ hess_inv[-2 * m + 2 :, -2 * m + 2 :]
                 @ np.concatenate((dmu_da[1:], dmu_deta[1:]))
             )
 
@@ -3435,8 +3435,8 @@ def fit(
     def function(
         _w: NDArray[np.float64], /, *_theta: np.float64
     ) -> NDArray[np.complex128]:
-        _a = np.asarray(_theta[n_p: n_p + n_a], dtype=np.float64)
-        _b = np.asarray(_theta[n_p + n_a:], dtype=np.float64)
+        _a = np.asarray(_theta[n_p : n_p + n_a], dtype=np.float64)
+        _b = np.asarray(_theta[n_p + n_a :], dtype=np.float64)
         h_ex = fun_ex(_a, _b)
         h_in = _frfun_local(_w[f_incl_idx], *_theta[:n_p])
         return np.concatenate((h_ex[:n_below], h_in, h_ex[n_below:]))
@@ -3497,7 +3497,7 @@ def fit(
                         np.zeros((n_b, 1)),
                         b_circ[:, : n_below - 1],
                         np.zeros((n_b, n_in)),
-                        b_circ[:, n_below - 1:],
+                        b_circ[:, n_below - 1 :],
                         np.zeros((n_b, 1)),
                     ),
                     axis=-1,
@@ -3518,7 +3518,7 @@ def fit(
                             np.zeros((n_b, 1)),
                             b_circ[:, : n_below - 1],
                             np.zeros((n_b, n_in)),
-                            b_circ[:, n_below - 1:],
+                            b_circ[:, n_below - 1 :],
                         ),
                         axis=-1,
                     )
@@ -3534,7 +3534,7 @@ def fit(
 
     def jac_fun(_x: NDArray[np.float64]) -> NDArray[np.float64]:
         p_est = _x[: n_p + n_a + n_b]
-        mu_est = xdata[:] - _x[n_p + n_a + n_b:]
+        mu_est = xdata[:] - _x[n_p + n_a + n_b :]
         jac_tl = np.zeros((n, n_p + n_a + n_b))
         jac_tr = np.diag(1 / sigma_x)
         fft_mu_est = rfft(mu_est)
@@ -3550,7 +3550,7 @@ def fit(
         lambda _p: _costfuntls(
             function,
             _p[: n_p + n_a + n_b],
-            xdata[:] - _p[n_p + n_a + n_b:],
+            xdata[:] - _p[n_p + n_a + n_b :],
             xdata[:],
             ydata[:],
             sigma_x[:],
@@ -3576,10 +3576,10 @@ def fit(
     p_opt = result.x[:n_p]
     p_cov = cov[:n_p, :n_p]
     p_err = np.sqrt(np.diag(p_cov))
-    delta = result.x[n_p + n_a + n_b:]
+    delta = result.x[n_p + n_a + n_b :]
 
     mu_opt = xdata - delta
-    mu_err = np.sqrt(np.diag(cov)[n_p + n_a + n_b:])
+    mu_err = np.sqrt(np.diag(cov)[n_p + n_a + n_b :])
     psi_opt = apply_frf(function, mu_opt, dt=dt, args=p_opt_all)
     epsilon = ydata - psi_opt
     resnorm = 2 * result.cost

--- a/src/thztools/thztools.py
+++ b/src/thztools/thztools.py
@@ -2571,7 +2571,7 @@ def _parse_noisefit_input(
             _epsilon = epsilon0
         else:
             _epsilon = _p[: m - 1]
-            _p = _p[m - 1:]
+            _p = _p[m - 1 :]
 
         _eta_on_dt = eta_scaled0 / dt if fix_eta else _p[: m - 1]
 
@@ -2621,7 +2621,7 @@ def _parse_noisefit_input(
             _epsilon = epsilon0
         else:
             _epsilon = _p[: m - 1]
-            _p = _p[m - 1:]
+            _p = _p[m - 1 :]
 
         _eta_on_dt = eta_scaled0 / dt if fix_eta else _p[: m - 1]
 
@@ -2740,7 +2740,7 @@ def _parse_noisefit_output(
         a_out = a0
     else:
         a_out = np.concatenate(([1.0], 1.0 + x_out[: m - 1] * scale_delta_a))
-        x_out = x_out[m - 1:]
+        x_out = x_out[m - 1 :]
 
     if fix_eta:
         eta_out = eta0
@@ -2818,7 +2818,7 @@ def _parse_noisefit_output(
 
     if not fix_a:
         err_a = np.concatenate(([0], err[: m - 1]))
-        err = err[m - 1:]
+        err = err[m - 1 :]
 
     if not fix_eta:
         err_eta = np.concatenate(([0], err[: m - 1]))
@@ -2859,18 +2859,18 @@ def _parse_noisefit_output(
 
         if fix_a and not fix_eta:
             var_a_eta = (
-                dmu_deta[1:].T @ hess_inv[-m + 1:, -m + 1:] @ dmu_deta[1:]
+                dmu_deta[1:].T @ hess_inv[-m + 1 :, -m + 1 :] @ dmu_deta[1:]
             )
         elif not fix_a and fix_eta:
             var_a_eta = (
-                dmu_da[1:].T @ hess_inv[-m + 1:, -m + 1:] @ dmu_da[1:]
+                dmu_da[1:].T @ hess_inv[-m + 1 :, -m + 1 :] @ dmu_da[1:]
             )
         elif fix_a and fix_eta:
             var_a_eta = 0
         else:
             var_a_eta = (
                 np.concatenate((dmu_da[1:], dmu_deta[1:])).T
-                @ hess_inv[-2 * m + 2:, -2 * m + 2:]
+                @ hess_inv[-2 * m + 2 :, -2 * m + 2 :]
                 @ np.concatenate((dmu_da[1:], dmu_deta[1:]))
             )
 
@@ -3437,8 +3437,8 @@ def fit(
     def function(
         _w: NDArray[np.float64], /, *_theta: np.float64
     ) -> NDArray[np.complex128]:
-        _a = np.asarray(_theta[n_p: n_p + n_a], dtype=np.float64)
-        _b = np.asarray(_theta[n_p + n_a:], dtype=np.float64)
+        _a = np.asarray(_theta[n_p : n_p + n_a], dtype=np.float64)
+        _b = np.asarray(_theta[n_p + n_a :], dtype=np.float64)
         h_ex = fun_ex(_a, _b)
         h_in = _frfun_local(_w[f_incl_idx], *_theta[:n_p])
         return np.concatenate((h_ex[:n_below], h_in, h_ex[n_below:]))
@@ -3501,7 +3501,7 @@ def fit(
                         np.zeros((n_b, 1)),
                         b_circ[:, : n_below - 1],
                         np.zeros((n_b, n_in)),
-                        b_circ[:, n_below - 1:],
+                        b_circ[:, n_below - 1 :],
                         np.zeros((n_b, 1)),
                     ),
                     axis=-1,
@@ -3522,7 +3522,7 @@ def fit(
                             np.zeros((n_b, 1)),
                             b_circ[:, : n_below - 1],
                             np.zeros((n_b, n_in)),
-                            b_circ[:, n_below - 1:],
+                            b_circ[:, n_below - 1 :],
                         ),
                         axis=-1,
                     )
@@ -3538,7 +3538,7 @@ def fit(
 
     def jac_fun(_x: NDArray[np.float64]) -> NDArray[np.float64]:
         p_est = _x[: n_p + n_a + n_b]
-        mu_est = xdata[:] - _x[n_p + n_a + n_b:]
+        mu_est = xdata[:] - _x[n_p + n_a + n_b :]
         jac_tl = np.zeros((n, n_p + n_a + n_b))
         jac_tr = np.diag(1 / sigma_x)
         fft_mu_est = rfft(mu_est)
@@ -3556,7 +3556,7 @@ def fit(
         lambda _p: _costfuntls(
             function,
             _p[: n_p + n_a + n_b],
-            xdata[:] - _p[n_p + n_a + n_b:],
+            xdata[:] - _p[n_p + n_a + n_b :],
             xdata[:],
             ydata[:],
             sigma_x[:],
@@ -3582,10 +3582,10 @@ def fit(
     p_opt = result.x[:n_p]
     p_cov = cov[:n_p, :n_p]
     p_err = np.sqrt(np.diag(p_cov))
-    delta = result.x[n_p + n_a + n_b:]
+    delta = result.x[n_p + n_a + n_b :]
 
     mu_opt = xdata - delta
-    mu_err = np.sqrt(np.diag(cov)[n_p + n_a + n_b:])
+    mu_err = np.sqrt(np.diag(cov)[n_p + n_a + n_b :])
     psi_opt = apply_frf(function, mu_opt, dt=dt, args=p_opt_all)
     epsilon = ydata - psi_opt
     resnorm = 2 * result.cost


### PR DESCRIPTION
When `fix_eta=True`, the delay parameter `eta` is not scaled with respect to the sampling time `dt` before being passed to the `objective` function within `_parse_noisefit_input`.