### PR TITLE
ENH: add freqbase utility for real FFT frequency sampling

### DIFF
--- a/src/thztools/__init__.py
+++ b/src/thztools/__init__.py
@@ -11,6 +11,7 @@ from thztools.thztools import (
     NoiseResult,
     apply_frf,
     fit,
+    freqbase,
     get_option,
     noisefit,
     options,
@@ -18,7 +19,6 @@ from thztools.thztools import (
     scaleshift,
     set_option,
     timebase,
-    freqbase,
     wave,
 )
 

--- a/src/thztools/__init__.py
+++ b/src/thztools/__init__.py
@@ -18,6 +18,7 @@ from thztools.thztools import (
     scaleshift,
     set_option,
     timebase,
+    freqbase,
     wave,
 )
 
@@ -36,5 +37,6 @@ __all__ = [
     "scaleshift",
     "set_option",
     "timebase",
+    "frqbase",
     "wave",
 ]

--- a/src/thztools/__init__.py
+++ b/src/thztools/__init__.py
@@ -37,6 +37,6 @@ __all__ = [
     "scaleshift",
     "set_option",
     "timebase",
-    "frqbase",
+    "freqbase",
     "wave",
 ]

--- a/src/thztools/thztools.py
+++ b/src/thztools/thztools.py
@@ -911,6 +911,51 @@ def timebase(
     return np.asarray(t_init + dt * np.arange(n), dtype=np.float64)
 
 
+def freqbase(n: int, *, dt: float | None = None) -> NDArray[np.float64]:
+    r"""
+    Discrete Fourier Transform sample frequencies for real FFTs.
+
+    Parameters
+    ----------
+    n : int
+        Number of samples in the time-domain signal.
+    dt : float or None, optional
+        Sampling time, normally in picoseconds. Default is None, which sets
+        the sampling time to ``thztools.options.sampling_time``. If both
+        ``dt`` and ``thztools.options.sampling_time`` are ``None``, the
+        sampling time is set to 1.0.
+
+    Returns
+    -------
+    f : ndarray
+        Array of length ``n//2 + 1`` of frequency samples corresponding to ``numpy.fft.rfftfreq``.
+
+    Warns
+    -----
+    UserWarning
+        If ``thztools.options.sampling_time`` and the ``dt`` parameter
+        are both not ``None`` and are set to different ``float`` values, the
+        function will set the sampling time to ``dt`` and raise a
+        :class:`UserWarning`.
+
+    Notes
+    -----
+    This function computes the frequency axis for the real FFT:
+
+        ``f = np.fft.rfftfreq(n, d=dt)``
+
+    Examples
+    --------
+    >>> import thztools as thz
+    >>> n, dt = 256, 0.05
+    >>> f = thz.freqbase(n, dt=dt)
+    >>> print(f[:3])
+    [0. 0.078125 0.15625 ]
+    """
+    dt = _assign_sampling_time(dt)
+    return np.asarray(np.fft.rfftfreq(n, d=dt), dtype=np.float64)
+
+
 def wave(
     n: int,
     *,
@@ -2573,7 +2618,7 @@ def _parse_noisefit_input(
             _epsilon = epsilon0
         else:
             _epsilon = _p[: m - 1]
-            _p = _p[m - 1 :]
+            _p = _p[m - 1:]
 
         _eta_on_dt = eta_scaled0 / dt if fix_eta else _p[: m - 1]
 
@@ -2623,7 +2668,7 @@ def _parse_noisefit_input(
             _epsilon = epsilon0
         else:
             _epsilon = _p[: m - 1]
-            _p = _p[m - 1 :]
+            _p = _p[m - 1:]
 
         _eta_on_dt = eta_scaled0 / dt if fix_eta else _p[: m - 1]
 
@@ -2742,7 +2787,7 @@ def _parse_noisefit_output(
         a_out = a0
     else:
         a_out = np.concatenate(([1.0], 1.0 + x_out[: m - 1] * scale_delta_a))
-        x_out = x_out[m - 1 :]
+        x_out = x_out[m - 1:]
 
     if fix_eta:
         eta_out = eta0
@@ -2819,7 +2864,7 @@ def _parse_noisefit_output(
 
     if not fix_a:
         err_a = np.concatenate(([0], err[: m - 1]))
-        err = err[m - 1 :]
+        err = err[m - 1:]
 
     if not fix_eta:
         err_eta = np.concatenate(([0], err[: m - 1]))
@@ -2860,18 +2905,18 @@ def _parse_noisefit_output(
 
         if fix_a and not fix_eta:
             var_a_eta = (
-                dmu_deta[1:].T @ hess_inv[-m + 1 :, -m + 1 :] @ dmu_deta[1:]
+                dmu_deta[1:].T @ hess_inv[-m + 1:, -m + 1:] @ dmu_deta[1:]
             )
         elif not fix_a and fix_eta:
             var_a_eta = (
-                dmu_da[1:].T @ hess_inv[-m + 1 :, -m + 1 :] @ dmu_da[1:]
+                dmu_da[1:].T @ hess_inv[-m + 1:, -m + 1:] @ dmu_da[1:]
             )
         elif fix_a and fix_eta:
             var_a_eta = 0
         else:
             var_a_eta = (
                 np.concatenate((dmu_da[1:], dmu_deta[1:])).T
-                @ hess_inv[-2 * m + 2 :, -2 * m + 2 :]
+                @ hess_inv[-2 * m + 2:, -2 * m + 2:]
                 @ np.concatenate((dmu_da[1:], dmu_deta[1:]))
             )
 
@@ -3437,8 +3482,8 @@ def fit(
     def function(
         _w: NDArray[np.float64], /, *_theta: np.float64
     ) -> NDArray[np.complex128]:
-        _a = np.asarray(_theta[n_p : n_p + n_a], dtype=np.float64)
-        _b = np.asarray(_theta[n_p + n_a :], dtype=np.float64)
+        _a = np.asarray(_theta[n_p: n_p + n_a], dtype=np.float64)
+        _b = np.asarray(_theta[n_p + n_a:], dtype=np.float64)
         h_ex = fun_ex(_a, _b)
         h_in = _frfun_local(_w[f_incl_idx], *_theta[:n_p])
         return np.concatenate((h_ex[:n_below], h_in, h_ex[n_below:]))
@@ -3499,7 +3544,7 @@ def fit(
                         np.zeros((n_b, 1)),
                         b_circ[:, : n_below - 1],
                         np.zeros((n_b, n_in)),
-                        b_circ[:, n_below - 1 :],
+                        b_circ[:, n_below - 1:],
                         np.zeros((n_b, 1)),
                     ),
                     axis=-1,
@@ -3520,7 +3565,7 @@ def fit(
                             np.zeros((n_b, 1)),
                             b_circ[:, : n_below - 1],
                             np.zeros((n_b, n_in)),
-                            b_circ[:, n_below - 1 :],
+                            b_circ[:, n_below - 1:],
                         ),
                         axis=-1,
                     )
@@ -3536,7 +3581,7 @@ def fit(
 
     def jac_fun(_x: NDArray[np.float64]) -> NDArray[np.float64]:
         p_est = _x[: n_p + n_a + n_b]
-        mu_est = xdata[:] - _x[n_p + n_a + n_b :]
+        mu_est = xdata[:] - _x[n_p + n_a + n_b:]
         jac_tl = np.zeros((n, n_p + n_a + n_b))
         jac_tr = np.diag(1 / sigma_x)
         fft_mu_est = rfft(mu_est)
@@ -3552,7 +3597,7 @@ def fit(
         return _costfuntls(
             function,
             _p[: n_p + n_a + n_b],
-            xdata[:] - _p[n_p + n_a + n_b :],
+            xdata[:] - _p[n_p + n_a + n_b:],
             xdata[:],
             ydata[:],
             sigma_x[:],
@@ -3586,10 +3631,10 @@ def fit(
     p_opt = result.x[:n_p]
     p_cov = cov[:n_p, :n_p]
     p_err = np.sqrt(np.diag(p_cov))
-    delta = result.x[n_p + n_a + n_b :]
+    delta = result.x[n_p + n_a + n_b:]
 
     mu_opt = xdata - delta
-    mu_err = np.sqrt(np.diag(cov)[n_p + n_a + n_b :])
+    mu_err = np.sqrt(np.diag(cov)[n_p + n_a + n_b:])
     psi_opt = apply_frf(function, mu_opt, dt=dt, args=p_opt_all)
     epsilon = ydata - psi_opt
     resnorm = 2 * result.cost

--- a/src/thztools/thztools.py
+++ b/src/thztools/thztools.py
@@ -2618,7 +2618,7 @@ def _parse_noisefit_input(
             _epsilon = epsilon0
         else:
             _epsilon = _p[: m - 1]
-            _p = _p[m - 1:]
+            _p = _p[m - 1 :]
 
         _eta_on_dt = eta_scaled0 / dt if fix_eta else _p[: m - 1]
 
@@ -2668,7 +2668,7 @@ def _parse_noisefit_input(
             _epsilon = epsilon0
         else:
             _epsilon = _p[: m - 1]
-            _p = _p[m - 1:]
+            _p = _p[m - 1 :]
 
         _eta_on_dt = eta_scaled0 / dt if fix_eta else _p[: m - 1]
 
@@ -2787,7 +2787,7 @@ def _parse_noisefit_output(
         a_out = a0
     else:
         a_out = np.concatenate(([1.0], 1.0 + x_out[: m - 1] * scale_delta_a))
-        x_out = x_out[m - 1:]
+        x_out = x_out[m - 1 :]
 
     if fix_eta:
         eta_out = eta0
@@ -2864,7 +2864,7 @@ def _parse_noisefit_output(
 
     if not fix_a:
         err_a = np.concatenate(([0], err[: m - 1]))
-        err = err[m - 1:]
+        err = err[m - 1 :]
 
     if not fix_eta:
         err_eta = np.concatenate(([0], err[: m - 1]))
@@ -2905,18 +2905,18 @@ def _parse_noisefit_output(
 
         if fix_a and not fix_eta:
             var_a_eta = (
-                dmu_deta[1:].T @ hess_inv[-m + 1:, -m + 1:] @ dmu_deta[1:]
+                dmu_deta[1:].T @ hess_inv[-m + 1 :, -m + 1 :] @ dmu_deta[1:]
             )
         elif not fix_a and fix_eta:
             var_a_eta = (
-                dmu_da[1:].T @ hess_inv[-m + 1:, -m + 1:] @ dmu_da[1:]
+                dmu_da[1:].T @ hess_inv[-m + 1 :, -m + 1 :] @ dmu_da[1:]
             )
         elif fix_a and fix_eta:
             var_a_eta = 0
         else:
             var_a_eta = (
                 np.concatenate((dmu_da[1:], dmu_deta[1:])).T
-                @ hess_inv[-2 * m + 2:, -2 * m + 2:]
+                @ hess_inv[-2 * m + 2 :, -2 * m + 2 :]
                 @ np.concatenate((dmu_da[1:], dmu_deta[1:]))
             )
 
@@ -3482,8 +3482,8 @@ def fit(
     def function(
         _w: NDArray[np.float64], /, *_theta: np.float64
     ) -> NDArray[np.complex128]:
-        _a = np.asarray(_theta[n_p: n_p + n_a], dtype=np.float64)
-        _b = np.asarray(_theta[n_p + n_a:], dtype=np.float64)
+        _a = np.asarray(_theta[n_p : n_p + n_a], dtype=np.float64)
+        _b = np.asarray(_theta[n_p + n_a :], dtype=np.float64)
         h_ex = fun_ex(_a, _b)
         h_in = _frfun_local(_w[f_incl_idx], *_theta[:n_p])
         return np.concatenate((h_ex[:n_below], h_in, h_ex[n_below:]))
@@ -3544,7 +3544,7 @@ def fit(
                         np.zeros((n_b, 1)),
                         b_circ[:, : n_below - 1],
                         np.zeros((n_b, n_in)),
-                        b_circ[:, n_below - 1:],
+                        b_circ[:, n_below - 1 :],
                         np.zeros((n_b, 1)),
                     ),
                     axis=-1,
@@ -3565,7 +3565,7 @@ def fit(
                             np.zeros((n_b, 1)),
                             b_circ[:, : n_below - 1],
                             np.zeros((n_b, n_in)),
-                            b_circ[:, n_below - 1:],
+                            b_circ[:, n_below - 1 :],
                         ),
                         axis=-1,
                     )
@@ -3581,7 +3581,7 @@ def fit(
 
     def jac_fun(_x: NDArray[np.float64]) -> NDArray[np.float64]:
         p_est = _x[: n_p + n_a + n_b]
-        mu_est = xdata[:] - _x[n_p + n_a + n_b:]
+        mu_est = xdata[:] - _x[n_p + n_a + n_b :]
         jac_tl = np.zeros((n, n_p + n_a + n_b))
         jac_tr = np.diag(1 / sigma_x)
         fft_mu_est = rfft(mu_est)
@@ -3597,7 +3597,7 @@ def fit(
         return _costfuntls(
             function,
             _p[: n_p + n_a + n_b],
-            xdata[:] - _p[n_p + n_a + n_b:],
+            xdata[:] - _p[n_p + n_a + n_b :],
             xdata[:],
             ydata[:],
             sigma_x[:],
@@ -3631,10 +3631,10 @@ def fit(
     p_opt = result.x[:n_p]
     p_cov = cov[:n_p, :n_p]
     p_err = np.sqrt(np.diag(p_cov))
-    delta = result.x[n_p + n_a + n_b:]
+    delta = result.x[n_p + n_a + n_b :]
 
     mu_opt = xdata - delta
-    mu_err = np.sqrt(np.diag(cov)[n_p + n_a + n_b:])
+    mu_err = np.sqrt(np.diag(cov)[n_p + n_a + n_b :])
     psi_opt = apply_frf(function, mu_opt, dt=dt, args=p_opt_all)
     epsilon = ydata - psi_opt
     resnorm = 2 * result.cost

--- a/tests/test_thztools.py
+++ b/tests/test_thztools.py
@@ -277,6 +277,31 @@ class TestTimebase:
         assert_allclose(t, t_expected, rtol=rtol, atol=eps)
 
 
+class TestFreqbase:
+    @pytest.mark.parametrize(
+        "dt",
+        [
+            None,
+            1.0,
+            2.0,
+        ],
+    )
+    def test_freqbase(self, dt: float | None) -> None:
+        n = 8
+
+        f = thztools.freqbase(n, dt=dt)
+
+        dt = _assign_sampling_time(dt)
+        f_expected = np.arange(n // 2 + 1) * (1.0 / (n * dt))
+
+        assert_allclose(f, f_expected, rtol=rtol, atol=eps)
+
+    def test_freqbase_length(self) -> None:
+        n = 8
+        f = thztools.freqbase(n)
+        assert len(f) == n // 2 + 1
+
+
 class TestWave:
     @pytest.mark.parametrize(
         "t0",
@@ -948,7 +973,7 @@ class TestHessNoiseFit:
             scale_delta_a=self.scale_delta_a,
             scale_eta_on_dt=scale_eta_on_dt,
             workers=self.workers,
-        )[: m - 1, m - 1 :]
+        )[: m - 1, m - 1:]
         assert_allclose(hess_a_eta, desired_hess_a_eta, atol=eps, rtol=rtol)
 
     def test_hess_eta_eta(self) -> None:

--- a/tests/test_thztools.py
+++ b/tests/test_thztools.py
@@ -973,7 +973,7 @@ class TestHessNoiseFit:
             scale_delta_a=self.scale_delta_a,
             scale_eta_on_dt=scale_eta_on_dt,
             workers=self.workers,
-        )[: m - 1, m - 1:]
+        )[: m - 1, m - 1 :]
         assert_allclose(hess_a_eta, desired_hess_a_eta, atol=eps, rtol=rtol)
 
     def test_hess_eta_eta(self) -> None:


### PR DESCRIPTION
This PR adds `freqbase`, a utility function that generates the frequency grid corresponding to `numpy.fft.rfftfreq`, using the same sampling-time handling as `timebase`. It provides a consistent and convenient way to construct frequency-domain sampling points for real-valued FFT-based analysis in `thztools`.